### PR TITLE
给项目添加CI发布

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,7 +1,7 @@
 # This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
-name: .NET
+name: Publish Package To Nuget
 
 on:
   push:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -45,4 +45,8 @@ jobs:
       shell: pwsh
       env:
         APIKEY: ${{ secrets.APIKEY }}
-      run: dotnet nuget push HomeKit.Net/bin/Release/HomeKit.Net.{{github.ref_name}}.nupkg --api-key $env:APIKEY --source https://api.nuget.org/v3/index.json
+        TagVersion: ${{github.ref_name}}
+      run: | 
+        $Version = $env:TagVersion -replace '^v'
+        $FullPath = "HomeKit.Net/bin/Release/HomeKit.Net.{0}.nupkg" -f $Version
+        dotnet nuget push $FullPath --api-key $env:APIKEY --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -27,7 +27,7 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
-    - name: Change Csproj Version
+    - name: Change Package Version
       shell: pwsh
       env:
         TagVersion: ${{github.ref_name}}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,48 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: .NET
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          6.0.x
+          8.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal
+    - name: Change Csproj Version
+      shell: pwsh
+      env:
+        TagVersion: ${{github.ref_name}}
+      run: |
+        $content = './HomeKit.Net/HomeKit.Net.csproj'
+        $xmldata = [xml](Get-Content $content)
+        $Version = "$env:TagVersion"
+        $node = $xmldata.Project.PropertyGroup
+        $node.Version = $Version
+        $xmldata.Save($content)
+    - name: Package
+      run: |
+        dotnet build -c Release .\HomeKit.Net\HomeKit.Net.csproj
+    - name: Upload to Nuget
+      shell: pwsh
+      env:
+        APIKEY: ${{ secrets.APIKEY }}
+      run: dotnet nuget push HomeKit.Net/HomeKit.Net/bin/Release/HomeKit.Net.{{github.ref_name}}.nupkg --api-key $env:APIKEY --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -45,4 +45,4 @@ jobs:
       shell: pwsh
       env:
         APIKEY: ${{ secrets.APIKEY }}
-      run: dotnet nuget push HomeKit.Net/HomeKit.Net/bin/Release/HomeKit.Net.{{github.ref_name}}.nupkg --api-key $env:APIKEY --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push HomeKit.Net/bin/Release/HomeKit.Net.{{github.ref_name}}.nupkg --api-key $env:APIKEY --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,7 +6,7 @@ name: .NET
 on:
   push:
     tags:
-      - '*.*.*'
+      - 'v*.*.*'
 
 jobs:
   build:
@@ -34,7 +34,7 @@ jobs:
       run: |
         $content = './HomeKit.Net/HomeKit.Net.csproj'
         $xmldata = [xml](Get-Content $content)
-        $Version = "$env:TagVersion"
+        $Version = $env:TagVersion -replace '^v'
         $node = $xmldata.Project.PropertyGroup
         $node.Version = $Version
         $xmldata.Save($content)


### PR DESCRIPTION
看这个项目的Nuget包和源码版本没有对起来，而且没有做任何CI，所以写个CI用，顺便修复 #2 。

注意事项：
1. 在项目的secrets中添加APIKEY，其中填写nuget上使用的apikey即可使用。
2. 想要发布的时候在对应的commit上推一个例如`v1.0.2`的tag就可以了